### PR TITLE
Add project URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ setup(
     long_description=long_description,
     packages=find_packages(),
     keywords=['python', 'giphy', 'giphy api', 'gif'],
+    project_urls={
+        "Source Code": "https://github.com/tawhidii/ezgiphy",
+        "Issue Tracker": "https://github.com/tawhidii/ezgiphy/issues",
+    },
     classifiers=[
         "Development Status :: Completed",
         "Intended Audience :: Developers",


### PR DESCRIPTION
I had trouble finding the GitHub repository for this package, so let's link to it.

Adding `project_urls` shows them on the left side of PyPI. It looks like this (under "verified details"):
https://pypi.org/project/pokemon-images/